### PR TITLE
attrs 21.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "attrs" %}
-{% set version = "21.2.0" %}
-{% set sha256 = "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb" %}
+{% set version = "21.4.0" %}
+{% set sha256 = "626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,14 @@ requirements:
 test:
   imports:
     - attr
+  requires:
+    - coverage
+    - hypothesis
+    - pip
+    - pympler
+    - six
+  commands:
+    - pip check
 
 about:
   home: https://attrs.readthedocs.io/en/stable/


### PR DESCRIPTION
Update attrs to 21.4.0

Bug tracker: https://github.com/python-attrs/attrs/issues
Changelog: https://github.com/python-attrs/attrs/blob/main/CHANGELOG.rst
License: https://github.com/python-attrs/attrs/blob/main/LICENSE
Upstream setup file: https://github.com/python-attrs/attrs/blob/21.4.0/setup.py
Upstream pyproject.toml: https://github.com/python-attrs/attrs/blob/21.4.0/pyproject.toml

Actions:
1. Add test/requires
2. Add `pip check`
3. Update `test/imports`: add `- attrs`, see https://github.com/python-attrs/attrs/blob/21.4.0/CHANGELOG.rst#2130-2021-12-28
4. Add `wheel` in `host`
