### PR TITLE
attrs 23.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ build:
   script: python -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch     # [not win]
   host:
     - pip
     - python
@@ -27,10 +30,19 @@ requirements:
 test:
   imports:
     - attr
+  source_files:
+    - tests
   requires:
+    - hypothesis
+    - cloudpickle
+    - pytest-xdist
+    - psutil
+    - mypy >=1.1.1
     - pip
+    - pytest >=4.3.0
   commands:
     - pip check
+    - pytest --fixtures tests -vv
 
 about:
   home: https://www.attrs.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,26 @@
 {% set name = "attrs" %}
-{% set version = "22.1.0" %}
-{% set sha256 = "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6" %}
+{% set version = "23.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015
+  patches:
+    - patches/001-remove-fancy-pypi-readme.patch
 
 build:
   number: 0
-  script: python -m pip install . --no-deps --ignore-installed
+  script: python -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
+    - hatch-vcs
   run:
     - python
 

--- a/recipe/patches/001-remove-fancy-pypi-readme.patch
+++ b/recipe/patches/001-remove-fancy-pypi-readme.patch
@@ -1,0 +1,67 @@
+From cf4a6c16634a20dda78aa08869496469e5d5d99a Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Fri, 22 Sep 2023 16:39:27 +0300
+Subject: [PATCH] Fix deps
+
+---
+ pyproject.toml                                | 37 +--------
+ 1 files changed, 1 insertions(+), 36 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index fb8fae3..010357e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: MIT
+ 
+ [build-system]
+-requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
++requires = ["hatchling", "hatch-vcs"]
+ build-backend = "hatchling.build"
+ 
+ 
+@@ -75,41 +75,6 @@ raw-options = { local_scheme = "no-local-version" }
+ [tool.hatch.build.targets.wheel]
+ packages = ["src/attr", "src/attrs"]
+ 
+-[tool.hatch.metadata.hooks.fancy-pypi-readme]
+-content-type = "text/markdown"
+-
+-# PyPI doesn't support the <picture> tag.
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """<p align="center">
+-  <a href="https://www.attrs.org/">
+-    <img src="https://raw.githubusercontent.com/python-attrs/attrs/main/docs/_static/attrs_logo.svg" width="35%" alt="attrs" />
+-  </a>
+-</p>
+-"""
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "README.md"
+-start-after = "<!-- teaser-begin -->"
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """
+-
+-## Release Information
+-
+-"""
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-path = "CHANGELOG.md"
+-pattern = "\n(###.+?\n)## "
+-
+-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+-text = """
+-
+----
+-
+-[Full changelog](https://www.attrs.org/en/stable/changelog.html)
+-"""
+-
+ 
+ # Make coverage play nicely with pytest-xdist.
+ [tool.hatch.build.targets.wheel.hooks.autorun]
+-- 
+2.39.0
+


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| defaults | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/attrs.svg)](https://anaconda.org/main/attrs) | [![Conda Version](https://img.shields.io/conda/vn/main/attrs.svg)](https://anaconda.org/main/attrs) | [![Conda Platforms](https://img.shields.io/conda/pn/main/attrs.svg)](https://anaconda.org/main/attrs) | ![Conda License](https://img.shields.io/conda/l/main/attrs) |

Changelog: https://github.com/python-attrs/attrs/blob/23.1.0/CHANGELOG.md
License: https://github.com/python-attrs/attrs/blob/23.1.0/LICENSE
Requirements: https://github.com/python-attrs/attrs/blob/23.1.0/pyproject.toml

Actions:
1. Add a patch to remove `fancy-pypi-readme` dependency
2. Clean up the recipe
3. Add `--no-build-isolation` to script
4. Update host: use hatchling, hatch-vcs
